### PR TITLE
Use tabs for Makefile commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+install:
+	pip install -e .[dev]
+
+format:
+	black .
+	ruff --fix .
+
+test:
+	pytest -q


### PR DESCRIPTION
## Summary
- Add Makefile with install, format, and test targets
- Ensure each command line is tab-indented

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6890f79988d4832b8cae871024e4f451