### PR TITLE
Ensure model registry populated by importing package

### DIFF
--- a/orchestration.py
+++ b/orchestration.py
@@ -1,0 +1,15 @@
+"""Orchestrator for forecasting models."""
+
+# Ensure all model modules are imported so their side effects register.
+import foresure_forecast.models  # noqa: F401
+from foresure_forecast.models.base import MODEL_REGISTRY
+
+
+def get_model(name: str):
+    """Retrieve a model class from the registry by name."""
+    return MODEL_REGISTRY[name]
+
+
+if __name__ == "__main__":
+    # Example: list available models
+    print("Registered models:", sorted(MODEL_REGISTRY))

--- a/src/foresure_forecast/__init__.py
+++ b/src/foresure_forecast/__init__.py
@@ -1,0 +1,1 @@
+"""ForeSure Forecast package."""

--- a/src/foresure_forecast/models/__init__.py
+++ b/src/foresure_forecast/models/__init__.py
@@ -1,0 +1,8 @@
+"""Model package that ensures all models are imported for registration."""
+
+# Import models so that they register themselves in MODEL_REGISTRY.
+from . import ses  # noqa: F401
+from . import des  # noqa: F401
+from . import tes  # noqa: F401
+
+__all__ = ["ses", "des", "tes"]


### PR DESCRIPTION
## Summary
- add `foresure_forecast/models/__init__.py` that imports SES/DES/TES modules so they self-register
- import `foresure_forecast.models` in `orchestration.py` to ensure registry is populated before model lookup

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6890f79aab20832bae7beb1eefac5158