### PR TITLE
Add model registry and orchestration import

### DIFF
--- a/src/foresure_forecast/__init__.py
+++ b/src/foresure_forecast/__init__.py
@@ -1,0 +1,3 @@
+"""Forecasting utilities package."""
+
+__all__ = []

--- a/src/foresure_forecast/models/__init__.py
+++ b/src/foresure_forecast/models/__init__.py
@@ -1,0 +1,6 @@
+"""Model registry and implementations for foresure_forecast."""
+
+from . import ses, des, tes  # noqa: F401
+from .base import MODEL_REGISTRY
+
+__all__ = ["MODEL_REGISTRY"]

--- a/src/foresure_forecast/models/base.py
+++ b/src/foresure_forecast/models/base.py
@@ -1,0 +1,11 @@
+"""Model registry utilities."""
+
+MODEL_REGISTRY = {}
+
+
+def register_model(name):
+    """Decorator to register models in :data:`MODEL_REGISTRY`."""
+    def decorator(obj):
+        MODEL_REGISTRY[name] = obj
+        return obj
+    return decorator

--- a/src/foresure_forecast/models/des.py
+++ b/src/foresure_forecast/models/des.py
@@ -1,0 +1,9 @@
+"""Double Exponential Smoothing model placeholder."""
+
+from .base import register_model
+
+
+@register_model("DES")
+class DES:
+    """Placeholder DES model."""
+    pass

--- a/src/foresure_forecast/models/ses.py
+++ b/src/foresure_forecast/models/ses.py
@@ -1,0 +1,9 @@
+"""Simple Exponential Smoothing model placeholder."""
+
+from .base import register_model
+
+
+@register_model("SES")
+class SES:
+    """Placeholder SES model."""
+    pass

--- a/src/foresure_forecast/models/tes.py
+++ b/src/foresure_forecast/models/tes.py
@@ -1,0 +1,9 @@
+"""Triple Exponential Smoothing model placeholder."""
+
+from .base import register_model
+
+
+@register_model("TES")
+class TES:
+    """Placeholder TES model."""
+    pass

--- a/src/foresure_forecast/orchestration.py
+++ b/src/foresure_forecast/orchestration.py
@@ -1,0 +1,10 @@
+"""Orchestration utilities for foresure_forecast models."""
+
+# Import models package to trigger model registration.
+import foresure_forecast.models  # noqa: F401
+from foresure_forecast.models import MODEL_REGISTRY
+
+
+def get_model(name: str):
+    """Retrieve a model class from the registry by name."""
+    return MODEL_REGISTRY[name]


### PR DESCRIPTION
## Summary
- introduce basic model registry with SES, DES, and TES placeholders
- ensure models package populates registry on import
- orchestration module now imports models package to trigger registration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890fb69a5ac832ba5916af80f28001e