### PR TITLE
Add CLI entry point and Python version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,17 @@ cd ForeSure-Forecast
 conda create -n forecast_env python=3.11
 conda activate forecast_env
 
-# Install dependencies
-pip install -r requirements.txt
+# Install the package (provides the `foresure-forecast` command)
+pip install -e .
 
 # Run your first forecast
-python forecast_engine.py --sales ./data/sales_history.csv
+foresure-forecast --sales ./data/sales_history.csv
+```
+
+## Usage Examples
+
+After installation, the package exposes a `foresure-forecast` command line tool:
+
+```bash
+foresure-forecast --help
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "foresure-forecast"
+version = "0.1.0"
+requires-python = ">=3.11"
+
+[project.scripts]
+foresure-forecast = "foresure_forecast.cli:app"


### PR DESCRIPTION
## Summary
- require Python 3.11+ via `pyproject.toml`
- expose `foresure-forecast` console command
- document CLI installation and usage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890fb69fff0832ba4534cc5f3f025a5