### PR TITLE
Handle metrics without sklearn and robust seasonal smoothing

### DIFF
--- a/src/foresure_forecast/models/des.py
+++ b/src/foresure_forecast/models/des.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import pandas as pd
-from sklearn.metrics import mean_absolute_percentage_error, mean_squared_error
 from statsmodels.tsa.holtwinters import ExponentialSmoothing
 
 from .base import BaseModel, MODEL_REGISTRY
+from .utils import rmse, mape
 
 
 class DESModel(BaseModel):
@@ -14,8 +14,8 @@ class DESModel(BaseModel):
         series = df["qty_sold"].fillna(0)
         model = ExponentialSmoothing(series, trend="add").fit()
         fitted = model.fittedvalues
-        rmse = mean_squared_error(series, fitted, squared=False)
-        mape = mean_absolute_percentage_error(series, fitted)
+        rmse_val = rmse(series, fitted)
+        mape_val = mape(series, fitted)
         forecast_vals = model.forecast(self.cfg.forecast_horizon_days)
         future_dates = pd.date_range(
             start=df["day_key"].max() + pd.Timedelta(days=1),
@@ -25,7 +25,12 @@ class DESModel(BaseModel):
         forecast = pd.DataFrame(
             {"day_key": future_dates, "forecast_qty": forecast_vals}
         )
-        return {"name": self.name, "rmse": rmse, "mape": mape, "forecast": forecast}
+        return {
+            "name": self.name,
+            "rmse": rmse_val,
+            "mape": mape_val,
+            "forecast": forecast,
+        }
 
 
 MODEL_REGISTRY[DESModel.name] = DESModel

--- a/src/foresure_forecast/models/ses.py
+++ b/src/foresure_forecast/models/ses.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import pandas as pd
-from sklearn.metrics import mean_absolute_percentage_error, mean_squared_error
 from statsmodels.tsa.holtwinters import SimpleExpSmoothing
 
 from .base import BaseModel, MODEL_REGISTRY
+from .utils import rmse, mape
 
 
 class SESModel(BaseModel):
@@ -14,8 +14,8 @@ class SESModel(BaseModel):
         series = df["qty_sold"].fillna(0)
         model = SimpleExpSmoothing(series).fit()
         fitted = model.fittedvalues
-        rmse = mean_squared_error(series, fitted, squared=False)
-        mape = mean_absolute_percentage_error(series, fitted)
+        rmse_val = rmse(series, fitted)
+        mape_val = mape(series, fitted)
         forecast_vals = model.forecast(self.cfg.forecast_horizon_days)
         future_dates = pd.date_range(
             start=df["day_key"].max() + pd.Timedelta(days=1),
@@ -25,7 +25,12 @@ class SESModel(BaseModel):
         forecast = pd.DataFrame(
             {"day_key": future_dates, "forecast_qty": forecast_vals}
         )
-        return {"name": self.name, "rmse": rmse, "mape": mape, "forecast": forecast}
+        return {
+            "name": self.name,
+            "rmse": rmse_val,
+            "mape": mape_val,
+            "forecast": forecast,
+        }
 
 
 MODEL_REGISTRY[SESModel.name] = SESModel

--- a/src/foresure_forecast/models/tes.py
+++ b/src/foresure_forecast/models/tes.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import pandas as pd
-from sklearn.metrics import mean_absolute_percentage_error, mean_squared_error
 from statsmodels.tsa.holtwinters import ExponentialSmoothing
 
 from .base import BaseModel, MODEL_REGISTRY
+from .utils import rmse, mape
 
 
 class TESModel(BaseModel):
@@ -12,15 +12,18 @@ class TESModel(BaseModel):
 
     def fit_forecast(self, df: pd.DataFrame) -> dict:
         series = df["qty_sold"].fillna(0)
-        model = ExponentialSmoothing(
-            series,
-            trend="add",
-            seasonal="add",
-            seasonal_periods=7,
-        ).fit()
+        try:
+            model = ExponentialSmoothing(
+                series,
+                trend="add",
+                seasonal="add",
+                seasonal_periods=7,
+            ).fit(initialization_method="estimated")
+        except ValueError:
+            model = ExponentialSmoothing(series, trend="add").fit()
         fitted = model.fittedvalues
-        rmse = mean_squared_error(series, fitted, squared=False)
-        mape = mean_absolute_percentage_error(series, fitted)
+        rmse_val = rmse(series, fitted)
+        mape_val = mape(series, fitted)
         forecast_vals = model.forecast(self.cfg.forecast_horizon_days)
         future_dates = pd.date_range(
             start=df["day_key"].max() + pd.Timedelta(days=1),
@@ -30,7 +33,12 @@ class TESModel(BaseModel):
         forecast = pd.DataFrame(
             {"day_key": future_dates, "forecast_qty": forecast_vals}
         )
-        return {"name": self.name, "rmse": rmse, "mape": mape, "forecast": forecast}
+        return {
+            "name": self.name,
+            "rmse": rmse_val,
+            "mape": mape_val,
+            "forecast": forecast,
+        }
 
 
 MODEL_REGISTRY[TESModel.name] = TESModel

--- a/src/foresure_forecast/models/utils.py
+++ b/src/foresure_forecast/models/utils.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def rmse(actual: pd.Series, predicted: pd.Series) -> float:
+    """Root mean squared error."""
+    actual_arr = actual.to_numpy(dtype=float)
+    pred_arr = predicted.to_numpy(dtype=float)
+    return float(np.sqrt(np.mean((actual_arr - pred_arr) ** 2)))
+
+
+def mape(actual: pd.Series, predicted: pd.Series) -> float:
+    """Mean absolute percentage error.
+
+    Any zero values in ``actual`` are replaced with a small epsilon to avoid
+    division by zero.
+    """
+    actual_arr = actual.to_numpy(dtype=float)
+    pred_arr = predicted.to_numpy(dtype=float)
+    denom = np.where(actual_arr == 0, np.finfo(float).eps, actual_arr)
+    return float(np.mean(np.abs((actual_arr - pred_arr) / denom)))


### PR DESCRIPTION
## Summary
- implement internal rmse/mape utilities to avoid scikit-learn dependency
- update SES, DES and TES models to use new metrics
- guard TES seasonal fit and fallback to non-seasonal trend when seasonal data is insufficient

## Testing
- `black src/foresure_forecast/models/utils.py src/foresure_forecast/models/ses.py src/foresure_forecast/models/des.py src/foresure_forecast/models/tes.py`
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_689109500e94832b94e96bbbaa555b85