### PR TITLE
fix: correct TES model implementation

### DIFF
--- a/src/foresure_forecast/models/tes.py
+++ b/src/foresure_forecast/models/tes.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import pandas as pd
-from sklearn.metrics import mean_absolute_percentage_error, mean_squared_error
 from statsmodels.tsa.holtwinters import ExponentialSmoothing
 
 from .base import BaseModel, MODEL_REGISTRY
+from .utils import mape, rmse
 
 
 class TESModel(BaseModel):
@@ -21,7 +21,7 @@ class TESModel(BaseModel):
         seasonal_period = self.cfg.category_seasonal_periods.get(
             category, self.cfg.default_seasonal_period
         )
- 
+
         model = ExponentialSmoothing(
             series,
             trend="add",
@@ -44,9 +44,8 @@ class TESModel(BaseModel):
             "name": self.name,
             "rmse": rmse_val,
             "mape": mape_val,
-            "forecast": forecast
+            "forecast": forecast,
         }
 
 
 MODEL_REGISTRY[TESModel.name] = TESModel
-


### PR DESCRIPTION
## Summary
- fix TES model to use internal rmse and mape helpers
- clean up return structure and ensure consistent formatting

## Testing
- `python -m black --check src/foresure_forecast/models/tes.py`
- `ruff check src/foresure_forecast/models/tes.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas'; ModuleNotFoundError: No module named 'foresure_forecast')*


------
https://chatgpt.com/codex/tasks/task_e_68923f7e45c8832b969ee6073bb349b3