### PR TITLE
fix: repair Makefile and export models

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,18 @@
+.PHONY: install format format-check lint test
+
 install:
-  pip install -e .[dev]
+	pip install -e .[dev]
 
 format:
-  black .
-  ruff --fix .
+	black .
+	ruff check --fix .
+
+format-check:
+	black --check .
+	ruff check .
+
+lint:
+	ruff check .
 
 test:
-  pytest -q
+	pytest -q

--- a/src/foresure_forecast/__init__.py
+++ b/src/foresure_forecast/__init__.py
@@ -9,4 +9,3 @@ if not logger.handlers:
     logger.setLevel(logging.INFO)
 
 __all__ = ["logger"]
-

--- a/src/foresure_forecast/cli.py
+++ b/src/foresure_forecast/cli.py
@@ -8,25 +8,25 @@ app = typer.Typer(add_completion=False)  # no subcommands, just one interface
 # Default path is always resolved from your project root
 DEFAULT_SALES_PATH = Path.cwd() / "data" / "fact_forecast_input.csv"
 
-@app.callback(
-    invoke_without_command=True,
-    help="Run the full forecasting pipeline."
-)
+
+@app.callback(invoke_without_command=True, help="Run the full forecasting pipeline.")
 def main(
     sales: Path = typer.Option(
         DEFAULT_SALES_PATH,
-        "--sales", "-s",
+        "--sales",
+        "-s",
         exists=True,
         file_okay=True,
         dir_okay=False,
         readable=True,
-        help="Path to fact_forecast_input.csv"
+        help="Path to fact_forecast_input.csv",
     )
 ):
     """
     Load your sales file and run the entire forecasting pipeline.
     """
     orchestration_run(str(sales))
+
 
 if __name__ == "__main__":
     app()

--- a/src/foresure_forecast/models/__init__.py
+++ b/src/foresure_forecast/models/__init__.py
@@ -9,4 +9,4 @@ from .des import DESModel
 from .tes import TESModel
 
 # (Optionally) expose them on the package level
-__all__ = ["SESModel", "DESModel", "TESModel"]
+__all__ = ["SESModel", "DESModel", "TESModel", "BaseModel", "MODEL_REGISTRY"]


### PR DESCRIPTION
## Summary
- fix Makefile syntax by using tabs and adding lint/format-check targets compatible with new Ruff CLI
- expose BaseModel and MODEL_REGISTRY to avoid unused import lint errors

## Testing
- `make format-check`
- `make lint`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'foresure_forecast'; ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_689241774184832ba50cd34c7c5e3187